### PR TITLE
Support to check if a pool already exists.

### DIFF
--- a/rados/conn.go
+++ b/rados/conn.go
@@ -91,6 +91,19 @@ func (c *Conn) OpenIOContext(pool string) (*IOContext, error) {
 	}
 }
 
+// Check if a pool exists
+func (c *Conn) PoolExists(poolName string) bool {
+    c_pool := C.CString(poolName)
+    defer C.free(unsafe.Pointer(c_pool))
+    ret := int64(C.rados_pool_lookup(c.cluster, c_pool))
+    if ret < 0 {
+        return false
+    }
+
+    return true
+}
+
+
 // ListPools returns the names of all existing pools.
 func (c *Conn) ListPools() (names []string, err error) {
 	buf := make([]byte, 4096)


### PR DESCRIPTION
Problem: go-ceph package does not have an API to check if a pool
already exists.

Solution: Librados API rados_pool_lokoup is now used to check if
a pool exists. New API is added in go-ceph called PoolExists with
this change.

Tests:
1. Tested with the use case mentioned above.