### PR TITLE
MRPHS-3026: Replace connection timed out error

### DIFF
--- a/rados/rados.go
+++ b/rados/rados.go
@@ -13,12 +13,18 @@ import (
 
 type RadosError int
 
-func (e RadosError) Error() string {
-	return fmt.Sprintf("rados: %s", C.GoString(C.strerror(C.int(-e))))
-}
-
 var RadosErrorNotFound = RadosError(-C.ENOENT)
 var RadosErrorPermissionDenied = RadosError(-C.EPERM)
+var RadosErrorConnectionTimedOut = RadosError(-C.ETIMEDOUT)
+var RadosErrorConnectionTimedOutStr = "Data cluster unavailable or misconfigured"
+
+func (e RadosError) Error() string {
+	if e == RadosErrorConnectionTimedOut {
+		return RadosErrorConnectionTimedOutStr
+	}
+
+	return fmt.Sprintf("rados: %s", C.GoString(C.strerror(C.int(-e))))
+}
 
 func GetRadosError(err int) error {
 	if err == 0 {


### PR DESCRIPTION
Problem: Connection timed out error is not intuitive to user.

Solution: Replace the error with "Data cluster unavailable or
misconfigured" error.

Test:
1. Tested the scenario mentioned above.